### PR TITLE
Fix screen size of kotlin minicap

### DIFF
--- a/experimental/app/build.gradle
+++ b/experimental/app/build.gradle
@@ -27,8 +27,8 @@ android {
         applicationId "io.devicefarmer.minicap"
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 1
-        versionName "0.3"
+        versionCode 2
+        versionName "0.7"
         archivesBaseName = "minicap"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/experimental/app/src/main/java/io/devicefarmer/minicap/Main.kt
+++ b/experimental/app/src/main/java/io/devicefarmer/minicap/Main.kt
@@ -18,8 +18,7 @@ package io.devicefarmer.minicap
 import android.os.Looper
 import android.util.Size
 import io.devicefarmer.minicap.provider.SurfaceProvider
-import org.slf4j.LoggerFactory
-import java.io.PrintStream
+import kotlin.math.roundToInt
 import kotlin.system.exitProcess
 
 
@@ -58,6 +57,7 @@ class Main {
             provider = if (params.projection == null) {
                 SurfaceProvider()
             } else {
+                params.projection.forceAspectRatio()
                 SurfaceProvider(
                     Size(
                         params.projection.targetSize.width,
@@ -106,9 +106,18 @@ class Main {
 }
 
 data class Projection(
-    val realSize: Size, val targetSize: Size,
+    val realSize: Size, var targetSize: Size,
     val orientation: Int
 ) {
+    fun forceAspectRatio() {
+        val aspect = realSize.width.toFloat() / realSize.height.toFloat()
+        targetSize = if (targetSize.height > targetSize.width / aspect) {
+            Size(targetSize.width, ((targetSize.width / aspect)).roundToInt())
+        } else {
+            Size((targetSize.height * aspect).roundToInt(), targetSize.height)
+        }
+    }
+
     override fun toString(): String =
         "${realSize.width}x${realSize.height}@${targetSize.width}x${targetSize.height}/${orientation}"
 }

--- a/experimental/app/src/main/java/io/devicefarmer/minicap/provider/BaseProvider.kt
+++ b/experimental/app/src/main/java/io/devicefarmer/minicap/provider/BaseProvider.kt
@@ -65,8 +65,8 @@ abstract class BaseProvider(private val targetSize: Size) : SimpleServer.Listene
 
     fun init(out: DisplayOutput) {
         imageReader = ImageReader.newInstance(
-            getScreenSize().width,
-            getScreenSize().height,
+            getTargetSize().width,
+            getTargetSize().height,
             PixelFormat.RGBA_8888,
             2
         )
@@ -111,6 +111,10 @@ abstract class BaseProvider(private val targetSize: Size) : SimpleServer.Listene
                 Bitmap.Config.ARGB_8888
             ).apply {
                 copyPixelsFromBuffer(buffer)
+            }.run {
+                //the image need to be cropped
+                Bitmap.createBitmap(this, 0, 0, getTargetSize().width, getTargetSize().height)
+            }.apply {
                 compress(Bitmap.CompressFormat.JPEG, q, out)
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devicefarmer/minicap-prebuilt",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "Prebuilt binaries of minicap.",
   "keywords": [
     "minicap"


### PR DESCRIPTION
Depending on the device one could have large black bands.
This PR fixes the screen images produced by kotlin minicap.
I also updated the version code/name to provide this apk as a 
fallback solution for stf.
