### PR TITLE
Fix rotation issue

### DIFF
--- a/experimental/app/src/main/java/io/devicefarmer/minicap/Main.kt
+++ b/experimental/app/src/main/java/io/devicefarmer/minicap/Main.kt
@@ -62,7 +62,8 @@ class Main {
                     Size(
                         params.projection.targetSize.width,
                         params.projection.targetSize.height
-                    )
+                    ),
+                    angleToRotation(params.projection.rotation)
                 )
             }
             provider.quality = params.quality
@@ -105,9 +106,18 @@ class Main {
     }
 }
 
+private fun angleToRotation(value: Int): Int =
+    when(value) {
+        0   -> 0
+        90  -> 1
+        180 -> 2
+        270 -> 3
+        else -> throw IllegalStateException("Invalid rotation")
+    }
+
 data class Projection(
     val realSize: Size, var targetSize: Size,
-    val orientation: Int
+    val rotation: Int
 ) {
     fun forceAspectRatio() {
         val aspect = realSize.width.toFloat() / realSize.height.toFloat()
@@ -119,7 +129,7 @@ data class Projection(
     }
 
     override fun toString(): String =
-        "${realSize.width}x${realSize.height}@${targetSize.width}x${targetSize.height}/${orientation}"
+        "${realSize.width}x${realSize.height}@${targetSize.width}x${targetSize.height}/${rotation}"
 }
 
 class Parameters private constructor(

--- a/experimental/app/src/main/java/io/devicefarmer/minicap/output/MinicapClientOutput.kt
+++ b/experimental/app/src/main/java/io/devicefarmer/minicap/output/MinicapClientOutput.kt
@@ -39,18 +39,18 @@ class MinicapClientOutput(
     /**
      * Sends the banner required at connection time
      */
-    fun sendBanner(screenSize: Size, targetSize: Size) {
+    fun sendBanner(screenSize: Size, targetSize: Size, rotation: Int ) {
         val byteArray = ByteArray(BANNER_SIZE)
         ByteBuffer.wrap(byteArray).apply {
             order(ByteOrder.LITTLE_ENDIAN)
             put(BANNER_VERSION.toByte())
             put(BANNER_SIZE.toByte())
             putInt(android.os.Process.myPid()) //PID
-            putInt(screenSize.width)//Width
-            putInt(screenSize.height)//Height
-            putInt(targetSize.width)//resized Width
-            putInt(targetSize.height)//resized height
-            put(0.toByte()) //orientation
+            putInt(screenSize.width)
+            putInt(screenSize.height)
+            putInt(targetSize.width)
+            putInt(targetSize.height)
+            put(rotation.toByte()) //as per libui ui::Rotation enum
             put(QUIRK_ALWAYS_UPRIGHT.toByte()) //quirk
         }
         with(socket.outputStream) {

--- a/experimental/app/src/main/java/io/devicefarmer/minicap/provider/BaseProvider.kt
+++ b/experimental/app/src/main/java/io/devicefarmer/minicap/provider/BaseProvider.kt
@@ -36,7 +36,7 @@ import java.nio.ByteBuffer
  * and sends the results to an output (could be a file for screenshot, or a minicap client receiving the
  * jpeg stream)
  */
-abstract class BaseProvider(private val targetSize: Size) : SimpleServer.Listener,
+abstract class BaseProvider(private val targetSize: Size, val rotation: Int) : SimpleServer.Listener,
     ImageReader.OnImageAvailableListener {
 
     companion object {
@@ -60,7 +60,7 @@ abstract class BaseProvider(private val targetSize: Size) : SimpleServer.Listene
     abstract fun screenshot(printer: PrintStream)
     abstract fun getScreenSize(): Size
 
-    fun getTargetSize(): Size = targetSize
+    fun getTargetSize(): Size = if(rotation%2 != 0) Size(targetSize.height, targetSize.width) else targetSize
     fun getImageReader(): ImageReader = imageReader
 
     fun init(out: DisplayOutput) {
@@ -75,7 +75,7 @@ abstract class BaseProvider(private val targetSize: Size) : SimpleServer.Listene
 
     override fun onConnection(socket: LocalSocket) {
         clientOutput = MinicapClientOutput(socket).apply {
-            sendBanner(getScreenSize(),getTargetSize())
+            sendBanner(getScreenSize(),getTargetSize(),rotation)
         }
         init(clientOutput)
     }

--- a/experimental/app/src/main/java/io/devicefarmer/minicap/provider/SurfaceProvider.kt
+++ b/experimental/app/src/main/java/io/devicefarmer/minicap/provider/SurfaceProvider.kt
@@ -33,8 +33,8 @@ import kotlin.system.exitProcess
  * Provides screen images using [SurfaceControl]. This is pretty similar to the native version
  * of minicap but here it is done at a higher level making things a bit easier.
  */
-class SurfaceProvider(targetSize: Size) : BaseProvider(targetSize) {
-    constructor() : this(currentScreenSize())
+class SurfaceProvider(targetSize: Size, orientation: Int) : BaseProvider(targetSize, orientation) {
+    constructor() : this(currentScreenSize(), currentRotation())
 
     companion object {
         private fun currentScreenSize(): Size {
@@ -42,6 +42,8 @@ class SurfaceProvider(targetSize: Size) : BaseProvider(targetSize) {
                 Size(this.size.width, this.size.height)
             }
         }
+
+        private fun currentRotation(): Int = currentDisplayInfo().rotation
 
         private fun currentDisplayInfo(): DisplayInfo {
             return DisplayManagerGlobal.getDisplayInfo(0)
@@ -53,9 +55,8 @@ class SurfaceProvider(targetSize: Size) : BaseProvider(targetSize) {
 
     val displayInfo: DisplayInfo = currentDisplayInfo()
 
-    override fun getScreenSize(): Size {
-        return displayInfo.size
-    }
+    override fun getScreenSize(): Size = displayInfo.size
+
 
     override fun screenshot(printer: PrintStream) {
         init(ScreenshotOutput(printer))

--- a/experimental/app/src/main/java/io/devicefarmer/minicap/utils/SurfaceControl.kt
+++ b/experimental/app/src/main/java/io/devicefarmer/minicap/utils/SurfaceControl.kt
@@ -73,7 +73,7 @@ object SurfaceControl {
 
     fun setDisplayProjection(
         displayToken: IBinder?,
-        orientation: Int,
+        rotation: Int, //Rotation0 = 0, Rotation90 = 1, Rotation180 = 2, Rotation270 = 3
         layerStackRect: Rect?,
         displayRect: Rect?
     ) {
@@ -82,7 +82,7 @@ object SurfaceControl {
                 "setDisplayProjection", IBinder::class.java,
                 Int::class.javaPrimitiveType, Rect::class.java, Rect::class.java
             )
-                .invoke(null, displayToken, orientation, layerStackRect, displayRect)
+                .invoke(null, displayToken, rotation, layerStackRect, displayRect)
         } catch (e: Exception) {
             logAndThrow(e)
         }


### PR DESCRIPTION
Rotation was not properly managed, assuming a portait mode.
This commit take care of reporting the orientation in the minicap
protocol and also the width x height switching when needed.
On the command line, a projection like "1080x2220@645x954/90"
leads to a target images of size 954x645.