### PR TITLE
Add secondary display selection (apk only)

### DIFF
--- a/experimental/app/src/main/java/io/devicefarmer/minicap/Main.kt
+++ b/experimental/app/src/main/java/io/devicefarmer/minicap/Main.kt
@@ -45,6 +45,7 @@ class Main {
                     Pair(p, elem)
                 } else {
                     when (lastKey) {
+                        "-d" -> p.displayId(elem.toInt())
                         "-n" -> p.socket(elem)
                         "-P" -> p.projection(elem)
                         "-Q" -> p.quality(elem.toInt())
@@ -55,10 +56,11 @@ class Main {
             }.first.build()
 
             provider = if (params.projection == null) {
-                SurfaceProvider()
+                SurfaceProvider(params.displayId)
             } else {
                 params.projection.forceAspectRatio()
                 SurfaceProvider(
+                    params.displayId,
                     Size(
                         params.projection.targetSize.width,
                         params.projection.targetSize.height
@@ -138,7 +140,8 @@ class Parameters private constructor(
     val socket: String,
     val quality: Int,
     val displayInfo: Boolean,
-    val frameRate: Float
+    val frameRate: Float,
+    val displayId: Int
 ) {
     data class Builder(
         var projection: Projection? = null,
@@ -146,7 +149,8 @@ class Parameters private constructor(
         var socket: String = "minicap",
         var quality: Int = 100,
         var displayInfo: Boolean = false,
-        var frameRate: Float = Float.MAX_VALUE
+        var frameRate: Float = Float.MAX_VALUE,
+        var displayId: Int = 0
     ) {
         //TODO make something more robust
         fun projection(p: String) = apply {
@@ -165,6 +169,7 @@ class Parameters private constructor(
         fun quality(value: Int) = apply { this.quality = value }
         fun displayInfo(enabled: Boolean) = apply { this.displayInfo = enabled }
         fun frameRate(value: Float) = apply { this.frameRate = value }
-        fun build() = Parameters(projection, screenshot, socket, quality, displayInfo, frameRate)
+        fun displayId(value: Int) = apply { this.displayId = value }
+        fun build() = Parameters(projection, screenshot, socket, quality, displayInfo, frameRate, displayId)
     }
 }

--- a/experimental/app/src/main/java/io/devicefarmer/minicap/provider/BaseProvider.kt
+++ b/experimental/app/src/main/java/io/devicefarmer/minicap/provider/BaseProvider.kt
@@ -24,6 +24,7 @@ import android.util.Size
 import io.devicefarmer.minicap.output.DisplayOutput
 import io.devicefarmer.minicap.output.MinicapClientOutput
 import io.devicefarmer.minicap.SimpleServer
+import io.devicefarmer.minicap.utils.DisplayManagerGlobal
 import org.slf4j.LoggerFactory
 import java.io.OutputStream
 import java.io.PrintStream
@@ -36,7 +37,7 @@ import java.nio.ByteBuffer
  * and sends the results to an output (could be a file for screenshot, or a minicap client receiving the
  * jpeg stream)
  */
-abstract class BaseProvider(private val targetSize: Size, val rotation: Int) : SimpleServer.Listener,
+abstract class BaseProvider(private val displayId: Int, private val targetSize: Size, val rotation: Int) : SimpleServer.Listener,
     ImageReader.OnImageAvailableListener {
 
     companion object {

--- a/experimental/app/src/main/java/io/devicefarmer/minicap/provider/SurfaceProvider.kt
+++ b/experimental/app/src/main/java/io/devicefarmer/minicap/provider/SurfaceProvider.kt
@@ -34,8 +34,8 @@ import kotlin.system.exitProcess
  * Provides screen images using [SurfaceControl]. This is pretty similar to the native version
  * of minicap but here it is done at a higher level making things a bit easier.
  */
-class SurfaceProvider(targetSize: Size, orientation: Int) : BaseProvider(targetSize, orientation) {
-    constructor() : this(currentScreenSize(), currentRotation())
+class SurfaceProvider(displayId: Int, targetSize: Size, orientation: Int) : BaseProvider(displayId, targetSize, orientation) {
+    constructor(display: Int) : this(display, currentScreenSize(), currentRotation())
 
     companion object {
         private fun currentScreenSize(): Size {
@@ -54,7 +54,7 @@ class SurfaceProvider(targetSize: Size, orientation: Int) : BaseProvider(targetS
     private val handler: Handler = Handler(Looper.getMainLooper())
     private var display: IBinder? = null
 
-    val displayInfo: DisplayInfo = currentDisplayInfo()
+    val displayInfo: DisplayInfo = DisplayManagerGlobal.getDisplayInfo(displayId)
 
     override fun getScreenSize(): Size = displayInfo.size
 

--- a/experimental/app/src/main/java/io/devicefarmer/minicap/utils/DisplayManagerGlobal.kt
+++ b/experimental/app/src/main/java/io/devicefarmer/minicap/utils/DisplayManagerGlobal.kt
@@ -54,4 +54,13 @@ object DisplayManagerGlobal {
             throw AssertionError(e)
         }
     }
+
+    fun getDisplayIds(): IntArray {
+        return try {
+            displayManager!!.javaClass.getMethod("getDisplayIds")
+                .invoke(displayManager) as IntArray
+        } catch (e: Exception) {
+            throw AssertionError(e)
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devicefarmer/minicap-prebuilt",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Prebuilt binaries of minicap.",
   "keywords": [
     "minicap"


### PR DESCRIPTION
let the user select the display to be streamed by minicap by using the "-d int_value" commandline parameter.
Could be a fix for https://github.com/DeviceFarmer/minicap/issues/28 but this is only provided by the apk.