### PR TITLE
fixbug : JpgEncoder::reserveData  return true when not need malloc me…

### DIFF
--- a/jni/minicap/JpgEncoder.cpp
+++ b/jni/minicap/JpgEncoder.cpp
@@ -50,7 +50,7 @@ JpgEncoder::getEncodedData() {
 bool
 JpgEncoder::reserveData(uint32_t width, uint32_t height) {
   if (width == mMaxWidth && height == mMaxHeight) {
-    return 0;
+    return true;
   }
 
   tjFree(mEncodedData);


### PR DESCRIPTION
When there is no change in width and height, there is no need to reallocate memory and reuse existing memory.